### PR TITLE
Explicit Policy Class for Mongoose

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ app.use(function (req, res, next) {
 To determine the appropriate policy for a record, record class or scope, the default policy finder attempts to find the name of the record type by looking in a few predefined places:
 
 * `object.policyClass` - Explicitly set policy for a record class
+* `object.model.policyClass` - For [Mongoose](http://mongoosejs.com) models to be explicitly set
 * `object.constructor.policyClass` - Explicitly set policy for a record instance
 * `object.modelName` - For [Mongoose](http://mongoosejs.com) models
 * `object.model.modelName` - For [Mongoose](http://mongoosejs.com) queries

--- a/lib/finder.js
+++ b/lib/finder.js
@@ -28,6 +28,7 @@ PolicyFinder.prototype.find = function () {
   if (Array.isArray(obj)) return new PolicyFinder(obj[0], this.options).find()
   if (!obj) return undefined
   if (obj.policyClass) return obj.policyClass
+  if (obj.model && obj.model.policyClass) return obj.model.policyClass
   if (obj.constructor && obj.constructor.policyClass) {
     return obj.constructor.policyClass
   }

--- a/test/finder.js
+++ b/test/finder.js
@@ -98,6 +98,11 @@ describe('Pandit PolicyFinder', function () {
       expect(finder.find()).to.equal('found')
     })
 
+    it('should return the `policyClass` property of the model if present', function () {
+      var finder = new PolicyFinder({model: {policyClass: 'found'}})
+      expect(finder.find()).to.equal('found')
+    })
+
     it('should return the `policyClass` property of the object\'s constructor if present', function () {
       var finder = new PolicyFinder({constructor: {policyClass: 'found'}})
       expect(finder.find()).to.equal('found')


### PR DESCRIPTION
Fun! With Mongoose! 

In some cases (like with a discriminator), the mongoose object passed does not have an explicit `policyClass` on the object, but does have it on the Model. This extends pandit to work in those cases. 